### PR TITLE
Fixed: compile narwhal with clang fails

### DIFF
--- a/packages/narwhal-jsc/Makefile
+++ b/packages/narwhal-jsc/Makefile
@@ -10,7 +10,7 @@ else
     CC        =clang
 endif
 
-CPPFLAGS  = -0s -force_cpusubtype_ALL -mmacosx-version-min=10.4 -arch i386
+CPPFLAGS  = -force_cpusubtype_ALL -mmacosx-version-min=10.4 -arch i386
 #CPPFLAGS += -g -O0
 #CPPFLAGS += -DDEBUG_ON
 #CPPFLAGS += -save-temps
@@ -97,7 +97,7 @@ config-webkit-debug:
 	# rm -f bin/narwhal-jsc
 	# ln -s narwhal-webkit-debug bin/narwhal-jsc
 
-config-jscocoa: 
+config-jscocoa:
 	echo 'export NARWHAL_JSC_MODE="jscocoa"' > narwhal-jsc.conf
 	# rm -f bin/narwhal-jsc
 	# ln -s narwhal-jscocoa bin/narwhal-jsc


### PR DESCRIPTION
Previously we tried to compile narwhal with the argument -0s. Or it's a non-existent arg.
