### PR TITLE
New: Added option to disable the build of CommonJS

### DIFF
--- a/packages/objective-j/lib/objective-j/jake/bundletask.js
+++ b/packages/objective-j/lib/objective-j/jake/bundletask.js
@@ -57,7 +57,10 @@ function BundleTask(aName, anApplication)
 {
     Task.apply(this, arguments);
 
-    this.setEnvironments([environment.Browser, environment.CommonJS]);
+    if (ENV["BUILD_COMMONJS"] == "NO")
+        this.setEnvironments([environment.Browser]);
+    else
+        this.setEnvironments([environment.Browser, environment.CommonJS]);
 
     this._author = null;
     this._email = null;


### PR DESCRIPTION
Previously when compiling, we compiled a browser and a commonJS version.
Now, if you set the env var BUILD_COMMONJS to "NO" it will only compile the browser version.
